### PR TITLE
Rename manifest_version to lock_file_version

### DIFF
--- a/release-lock-file-spec.md
+++ b/release-lock-file-spec.md
@@ -123,16 +123,14 @@ this field **must** be present.
 
 ### Contracts: `contracts`
 
-The `contracts` field declares information about the deployed contracts.
-
-* a single *Contract Instance Object*
-* a List of *Contract Instance Objects*
+The `contracts` field declares information about the deployed contracts
+included within this release.
 
 * Key: `contracts`
-* Type:  *any of:*
-    - *Contract Instance Object* 
-    - List of *Contract Instance Object* 
-    - Hash of (String: *Contract Instance Object*) where keys are valid contract names matching the regex `[_a-zA-Z][_a-zA-Z0-9]*`.
+* Type:  Object (String: *Contract Instance Object*)
+* Format: 
+    * All keys **must** be valid contract names matching the regex `[_a-zA-Z][_a-zA-Z0-9]*`.
+    * All values **must** conform to the *Contract Instance Object* definition.
 
 
 #### The *Contract Instance Object*

--- a/release-lock-file-spec.md
+++ b/release-lock-file-spec.md
@@ -40,13 +40,13 @@ be included.  Custom fields **should** be prefixed with `x-` to prevent name
 collisions with future versions of the specification.
 
 
-### Manifest Version: `manifest_version`
+### Lock File Version: `lock_file_version`
 
 
-The `manifest_version` field defines the specification version that this
+The `lock_file_version` field defines the specification version that this
 document conforms to.  All release lock files **must** include this field.
 
-* Key: `manifest_version`
+* Key: `lock_file_version`
 * Type: Integer
 * Allowed Values: `1`
 


### PR DESCRIPTION
This renames the field in the Release Lock File from `manifest_version` to `lock_file_version`.  Open to a better name if anyone can think of one.