### PR TITLE
adding json-schema and document generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+var parse = require('json-schema-to-markdown')
+const fs = require('fs');
+const path = require('path');
+
+fs.readdir("./spec/", (err, files) => {
+  files.forEach(file => {
+    let jsonFile = fs.readFileSync(path.join('spec',file), "utf8");
+    let json = JSON.parse(jsonFile);
+    let filename = file.split('.')[0] + '-s.md';
+    let md = parse(json);
+    fs.writeFileSync(filename, md);
+  });
+})

--- a/package-manifest-s.md
+++ b/package-manifest-s.md
@@ -1,0 +1,130 @@
+# Package Manifest Specification
+
+This document defines the specification for the **Package Manifest**. The
+ package manifest contains meta data about the package as well as dependencies
+ needed for installation of the package.
+ 
+ 
+## Guiding Principles
+ 
+The package manifest specification makes the following assumptions about the
+ document lifecycle.
+ 
+1. Package manifests are long lived documents that will be modified regularly
+2. Package manifests will primarily be consumed by package managers.
+3. Package manifests will primarily be used by package indexes to popululate basic package metadata.
+2. Package Managers will typically be used to assist in the creation and modification of Package Manifest documents.
+4. Package Manifest documents will occasionally be created and modified manually by people.
+4. Package manifests will typically be stored alongised the package source code.
+ 
+ 
+## Format
+ 
+ The canoonical format for the package manifest is a JSON document containing a
+ single JSON object.
+ 
+ 
+## Filename
+ 
+ Convention is to name this document `epm.json` which is short for *'ethereum
+ package manifest'*.
+ 
+ 
+## Document Specification
+ 
+ The following fields are defined for the package manifest.  Custom fields may
+ be included.  Custom fields **should** be prefixed with `x-` to prevent name
+ collisions with future versions of the specification.
+This document defines the specification for the Package Manifest. The package manifest contains meta data about the package as well as dependencies needed for installation of the package.
+
+The schema defines the following properties:
+
+## `package_name` (string)
+
+ The `package_name` field defines a human readable name for this package.  All manifests **should** include this field.
+
+## `manifest_version` (integer, required)
+
+ The `manifest_version` field defines the version of the ethereum package manifest specification (this document) that this manifest conforms to. All manifests **must** include this field.
+
+Default: `1`
+
+## `authors` (array)
+
+ The `authors` field defines a list of human readable names for the authors of this package.  All manifests **should** include this field.
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
+## `version` (string, required)
+
+ The `version` field declares the current version number of this package.  This value **should** be conform to the [semver](http://semver.org/) version numbering specification.  All manifests **must** this field.
+
+Default: `"0.0.1-dev"`
+
+## `license` (string)
+
+The `license` field declares the license under which this package is released.  This value **should** be conform to the [SPDX](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange) format.  All manifests **should** include this field.
+
+Default: `"MIT"`
+
+## `description` (string)
+
+The `description` field *should* be used to provide additional detail that may be relevant for the package.
+
+Default: `""`
+
+## `keywords` (array)
+
+The `keywords` field *should* be used to provide relevant keywords related to this package.
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
+## `links` (object)
+
+ The `links` field *should* be used to provide URIs to relevant resources associated with this package.  When possible, authors *should* use the following keys for the following common resources.
+
+## `sources` (array)
+
+ The `sources` field defines a set of source files that comprise the source code for the project.  This list **should** be included in all manifests.  Package managers **should** use this field to inform population of the `sources` field in the *release lock file*.  
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
+## `contracts` (array)
+
+The `contracts` field defines a list of contract names that should be included in the release manifest when generating a release.
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
+## `dependencies` (object)
+
+the `dependencies` field defines a key/value mapping of ethereum packages that this project depends on.
+
+Default:
+
+```
+{}
+```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "epm-spec",
+  "name": "ethpm-spec",
   "version": "1.0.0",
   "description": "Ethereum Package Manager Specifications",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "epm-spec",
+  "version": "1.0.0",
+  "description": "Ethereum Package Manager Specifications",
+  "main": "index.js",
+  "scripts": {
+    "build": ""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ethpm/epm-spec.git"
+  },
+  "keywords": [
+    "ethereum",
+    "package",
+    "manager",
+    "epm",
+    "ethpm"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ethpm/epm-spec/issues"
+  },
+  "homepage": "https://github.com/ethpm/epm-spec#readme",
+  "dependencies": {
+    "json-schema-to-markdown": "^1.0.3"
+  }
+}

--- a/release-lock-file-s.md
+++ b/release-lock-file-s.md
@@ -1,0 +1,100 @@
+# Release Lock File Specification
+
+ This document defines the specification for the **Release Lock File**.  The release lock file provides metadata about the package and in most cases should provide sufficient information about the packaged contracts and its dependencies to do bytecode verification of its contracts.
+ ## Guiding Principles
+ 
+ The release lock file specification makes the following assumptions about the
+ document lifecycle.
+ 
+ 1. Release lock files are intended to be generated programatically by package management software as part of the release process.
+ 2. Release lock files will be consumed by package managers during tasks like installing package dependencies or building and deploying new releases.
+ 3. Release lock files will typically **not** be stored alongside the source, but rather by package registries *or* referenced by package registries and stored in something akin to IPFS.
+ 
+ 
+## Format
+ 
+ The canonical format for the package manifest is a JSON document containing a
+ single JSON object.  
+ 
+ 
+## Filename
+ 
+ Convention is to name this document `<version>.lock` where the `<version>`
+ component is the full version string for the release.
+ 
+ Package managers which are installing dependencies for development versions
+ should keep their own version of this document under the lowercased name of the
+ package manager such as `truffle.lock` or `dapple.lock`.  This file would
+ typically be excluded from version control.
+ 
+ 
+## Document Specification
+ 
+ The following fields are defined for the release lock file.  Custom fields may
+ be included.  Custom fields **should** be prefixed with `x-` to prevent name
+ collisions with future versions of the specification.
+ 
+
+The schema defines the following properties:
+
+## `lock_file_version` (integer, required)
+
+ The `lock_file_version` field defines the specification version that this document conforms to.  All release lock files **must** include this field.  
+
+Default: `1`
+
+## `package_manifest` (string, required)
+
+ The `package_manifest` field references the package's Package Manifest document as it existed at the time this release was created.  All release lock files **must** include this field.  The manifest may be referenced using an IPFS URI or by directly embedding the document under this key.  
+
+## `version` (string, required)
+
+ The `version` field declares the version number of this release.  This value **must** be included in all release lock files.  This value **should** be conform to the [semver](http://semver.org/) version numbering specification.  
+
+Default: `"0.0.1-dev"`
+
+## `license` (string)
+
+The `license` field declares the license under which this package is released.  This value **should** be conform to the [SPDX](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange) format.  All release lock files **should** include this field.
+
+Default: `"MIT"`
+
+## `sources` (array)
+
+The sources field defines a set of source files that comprise the source code for the project. This list should be included in all manifests. Package managers should use this field to inform population of the sources field in the release lock file.
+
+ * All keys **must** conform to *one of* the following formats.
+     * Begins with a `./` to denote that it is a filesystem path.
+     * Is a valid contract name matching the regex `[_a-zA-Z][_a-zA-Z0-9]*`.
+ * All keys which are formatted to be filesystem paths **must** conform to *all* of the following rules:
+     * Resolving the filesystem paths must result path that is *under* the current working directory.
+ * *If* the key is a contract name the value **must** be the source string for that contract.
+ * *If* the key is a filesystem path the value **must** conform to *one of* the following formats.
+     * IPFS URI
+         * *If* the resulting document is a directory the key should be interpreted as a directory path.
+         * *If* the resulting document is a file the key should be interpreted as a file path.
+
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
+## `chain` (array)
+
+The `chain` field defines the blockchain that should be used for any addresses provided with this package.  A blockchain is defined using [BIP-122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki).  A matching blockchain is one on which all resources defined by the list of BIP122 URIs can be found. *If* this release lock file includes any addressed contracts this field **must** be present.  Convention is to define a chain using a single URI which points to the latest observable block hash and includes the genesis hash as the `chain_id`.
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[]
+```
+
+## `contracts` (object)
+
+The `contracts` field declares information about the deployed contracts included within this release.

--- a/spec/package-manifest.schema.json
+++ b/spec/package-manifest.schema.json
@@ -1,0 +1,103 @@
+{
+  "title": "Package Manifest Specification",
+  "description": "This document defines the specification for the **Package Manifest**. The\n package manifest contains meta data about the package as well as dependencies\n needed for installation of the package.\n \n \n## Guiding Principles\n \nThe package manifest specification makes the following assumptions about the\n document lifecycle.\n \n1. Package manifests are long lived documents that will be modified regularly\n2. Package manifests will primarily be consumed by package managers.\n3. Package manifests will primarily be used by package indexes to popululate basic package metadata.\n2. Package Managers will typically be used to assist in the creation and modification of Package Manifest documents.\n4. Package Manifest documents will occasionally be created and modified manually by people.\n4. Package manifests will typically be stored alongised the package source code.\n \n \n## Format\n \n The canoonical format for the package manifest is a JSON document containing a\n single JSON object.\n \n \n## Filename\n \n Convention is to name this document `epm.json` which is short for *'ethereum\n package manifest'*.\n \n \n## Document Specification\n \n The following fields are defined for the package manifest.  Custom fields may\n be included.  Custom fields **should** be prefixed with `x-` to prevent name\n collisions with future versions of the specification.\nThis document defines the specification for the Package Manifest. The package manifest contains meta data about the package as well as dependencies needed for installation of the package.",
+  "type": "object",
+  "required": ["manifest_version", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "package_name": {
+      "title": "Package Name",
+      "type": "string",
+      "description": " The `package_name` field defines a human readable name for this package.  All manifests **should** include this field."
+    },
+    "manifest_version": {
+      "type": "integer",
+      "title": "Manifest Version",
+      "description": " The `manifest_version` field defines the version of the ethereum package manifest specification (this document) that this manifest conforms to. All manifests **must** include this field.",
+      "default": 1
+    },
+    "authors": {
+      "title": "Authors",
+      "type": "array",
+      "description": " The `authors` field defines a list of human readable names for the authors of this package.  All manifests **should** include this field.",
+      "default": [],
+      "items": {
+        "title": "Name and Email of the authors",
+        "type": "string"
+      }
+    },
+    "version": {
+      "title": "Version",
+      "type": "string",
+      "description": " The `version` field declares the current version number of this package.  This value **should** be conform to the [semver](http://semver.org/) version numbering specification.  All manifests **must** this field.",
+      "default": "0.0.1-dev"
+    },
+
+    "license": {
+      "title": "License",
+      "type": "string",
+      "default": "MIT",
+      "description": "The `license` field declares the license under which this package is released.  This value **should** be conform to the [SPDX](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange) format.  All manifests **should** include this field."
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "description": "The `description` field *should* be used to provide additional detail that may be relevant for the package.",
+      "default": ""
+    },
+
+    "keywords": {
+      "title": "Keywords",
+      "type": "array",
+      "default": [],
+      "description": "The `keywords` field *should* be used to provide relevant keywords related to this package.",
+      "items": {
+        "title": "Keyword",
+        "type": "string"
+      }
+    },
+
+    "links": {
+      "title": "Links",
+      "description": " The `links` field *should* be used to provide URIs to relevant resources associated with this package.  When possible, authors *should* use the following keys for the following common resources.",
+      "type": "object",
+      "blackbox": true
+    },
+
+    "sources": {
+      "title": "Sources",
+      "type": "array",
+      "description": " The `sources` field defines a set of source files that comprise the source code for the project.  This list **should** be included in all manifests.  Package managers **should** use this field to inform population of the `sources` field in the *release lock file*.  ",
+      "items": {
+        "title": "Source Path",
+        "type": "string",
+        "description": ": Strings must be formatted as valid filesystem paths. All paths must be relative paths beginning with ./. All paths must resolve to to a path located within the base directory of the package (i.e., the location of epm.json"
+      },
+      "default": []
+    },
+
+    "contracts": {
+      "title": "Contracts",
+      "description": "The `contracts` field defines a list of contract names that should be included in the release manifest when generating a release.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "title": "Contract Name"
+      },
+      "default": []
+    },
+
+    "dependencies": {
+      "title": "Dependencies",
+      "description": "the `dependencies` field defines a key/value mapping of ethereum packages that this project depends on.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z][-a-zA-Z0-9_]*$": {
+          "type": "string",
+          "description": "IPFS URI: The resolved document must be a valid release lock file."
+        }
+      },
+      "default": {}
+    }
+  }
+}

--- a/spec/release-lock-file.schema.json
+++ b/spec/release-lock-file.schema.json
@@ -49,7 +49,8 @@
       "items": {
         "title": "URI",
         "description": "must be valid BIP122 URIS",
-        "type": "string"
+        "type": "string",
+        "format": "uri"
       }
     },
     "contracts": {
@@ -63,7 +64,8 @@
           "properties": {
             "contract_name": {
               "type": "string",
-              "description": "Valid contract name matching regular expression `[_a-zA-Z][_a-zA-Z0-9]*]`"
+              "description": "Valid contract name matching regular expression `[_a-zA-Z][_a-zA-Z0-9]*]`",
+              "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
             },
             "address": {
               "type": "string",

--- a/spec/release-lock-file.schema.json
+++ b/spec/release-lock-file.schema.json
@@ -1,0 +1,134 @@
+{
+  "title": "Release Lock File Specification",
+  "description": " This document defines the specification for the **Release Lock File**.  The release lock file provides metadata about the package and in most cases should provide sufficient information about the packaged contracts and its dependencies to do bytecode verification of its contracts.\n ## Guiding Principles\n \n The release lock file specification makes the following assumptions about the\n document lifecycle.\n \n 1. Release lock files are intended to be generated programatically by package management software as part of the release process.\n 2. Release lock files will be consumed by package managers during tasks like installing package dependencies or building and deploying new releases.\n 3. Release lock files will typically **not** be stored alongside the source, but rather by package registries *or* referenced by package registries and stored in something akin to IPFS.\n \n \n## Format\n \n The canonical format for the package manifest is a JSON document containing a\n single JSON object.  \n \n \n## Filename\n \n Convention is to name this document `<version>.lock` where the `<version>`\n component is the full version string for the release.\n \n Package managers which are installing dependencies for development versions\n should keep their own version of this document under the lowercased name of the\n package manager such as `truffle.lock` or `dapple.lock`.  This file would\n typically be excluded from version control.\n \n \n## Document Specification\n \n The following fields are defined for the release lock file.  Custom fields may\n be included.  Custom fields **should** be prefixed with `x-` to prevent name\n collisions with future versions of the specification.\n ",
+  "type": "object",
+  "required": ["lock_file_version", "package_manifest", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "lock_file_version": {
+      "type": "integer",
+      "title": "Lock File Version",
+      "description": " The `lock_file_version` field defines the specification version that this document conforms to.  All release lock files **must** include this field.  ",
+      "default": 1
+    },
+
+    "package_manifest": {
+      "title": "Package Manifest",
+      "type": "string",
+      "description": " The `package_manifest` field references the package's Package Manifest document as it existed at the time this release was created.  All release lock files **must** include this field.  The manifest may be referenced using an IPFS URI or by directly embedding the document under this key.  "
+    },
+    "version": {
+      "title": "Version",
+      "type": "string",
+      "description": " The `version` field declares the version number of this release.  This value **must** be included in all release lock files.  This value **should** be conform to the [semver](http://semver.org/) version numbering specification.  ",
+      "default": "0.0.1-dev"
+    },
+
+    "license": {
+      "title": "License",
+      "type": "string",
+      "default": "MIT",
+      "description": "The `license` field declares the license under which this package is released.  This value **should** be conform to the [SPDX](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange) format.  All release lock files **should** include this field."
+    },
+    "sources": {
+      "title": "Sources",
+      "type": "array",
+      "description": "The sources field defines a set of source files that comprise the source code for the project. This list should be included in all manifests. Package managers should use this field to inform population of the sources field in the release lock file.\n\n * All keys **must** conform to *one of* the following formats.\n     * Begins with a `./` to denote that it is a filesystem path.\n     * Is a valid contract name matching the regex `[_a-zA-Z][_a-zA-Z0-9]*`.\n * All keys which are formatted to be filesystem paths **must** conform to *all* of the following rules:\n     * Resolving the filesystem paths must result path that is *under* the current working directory.\n * *If* the key is a contract name the value **must** be the source string for that contract.\n * *If* the key is a filesystem path the value **must** conform to *one of* the following formats.\n     * IPFS URI\n         * *If* the resulting document is a directory the key should be interpreted as a directory path.\n         * *If* the resulting document is a file the key should be interpreted as a file path.\n",
+      "items": {
+        "title": "Source Path",
+        "type": "string",
+        "description": ": Strings must be formatted as valid filesystem paths. All paths must be relative paths beginning with ./. All paths must resolve to to a path located within the base directory of the package (i.e., the location of epm.json"
+      },
+      "default": []
+    },
+    "chain": {
+      "title": "Chain",
+      "type": "array",
+      "description": "The `chain` field defines the blockchain that should be used for any addresses provided with this package.  A blockchain is defined using [BIP-122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki).  A matching blockchain is one on which all resources defined by the list of BIP122 URIs can be found. *If* this release lock file includes any addressed contracts this field **must** be present.  Convention is to define a chain using a single URI which points to the latest observable block hash and includes the genesis hash as the `chain_id`.",
+      "default": [],
+      "items": {
+        "title": "URI",
+        "description": "must be valid BIP122 URIS",
+        "type": "string"
+      }
+    },
+    "contracts": {
+      "title": "Contracts",
+      "type": "object",
+      "description": "The `contracts` field declares information about the deployed contracts included within this release.",
+      "patternProperties": {
+        "^[a-zA-Z][-a-zA-Z0-9_]*$": {
+          "type": "object",
+          "description": "A *Contract Instance Object* is an object with the following key/values.",
+          "properties": {
+            "contract_name": {
+              "type": "string",
+              "description": "Valid contract name matching regular expression `[_a-zA-Z][_a-zA-Z0-9]*]`"
+            },
+            "address": {
+              "type": "string",
+              "description": "Hex encoded ethereum address of the deployed contract."
+            },
+            "deploy_transaction": {
+              "type": "string",
+              "description": "[BIP122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) URI which defines the transaction in which this contract was created."
+            },
+            "deploy_block": {
+              "type": "string",
+              "description": "[BIP122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) URI which defines the block in which this contract was created."
+            },
+            "bytecode": {
+              "type": "string",
+              "description": "Hex encoded unlinked bytecode for the compiled contract."
+            },
+            "runtime_bytecode": {
+              "type": "string",
+              "description": "Hex encoded unlinked runtime portion of the bytecode for the compiled contract."
+            },
+            "abi": {
+              "type": "array",
+              "description": "see https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#json",
+              "items": {
+                "type": "object",
+                "description": "",
+                "blackbox": true
+              }
+            },
+            "natspec": {
+              "type": "object",
+              "description": "Combined [UserDoc](https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format#user-documentation) and [DevDoc](https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format#developer-documentation)",
+              "blackbox": true
+            },
+            "compiler": {
+              "title": "Compiler",
+              "type": "object",
+              "description": "Properties of the `compiler` object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "settings": {
+                  "type": "object",
+                  "blackbox": true
+                }
+              }
+            },
+            "link_dependencies": {
+              "description": "Required to have an entry for each link reference found in either the `bytecode` or `runtime_bytecode` fields.  \n\n * All keys **must** be strings which are formatted as valid link targets.",
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "type": "string",
+                  "description": "* All values **must** conform to *one of* the following formats:\n * A hex encoded ethereum address.\n * A [json pointer](https://tools.ietf.org/html/rfc6901) to another *Contract Instance Object* in the release lock file.\n * An IPFS URI with a JSON point in the fragment portion of the URI.  The IPFS hash must resolves to a valid release lock file.  The json pointer **must** resolves to a *Contract Instance Object* within the release lock file.\n"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This branch includes a first json-schema draft of `package-manifest-spec` and `release-lock-file-spec`. It also includes an automatic json-schema to markdown documentation generator which unfortunately don't captures all available information, therefore the original documentation are kept in place, although I would argue to deprecate them as soon as a sufficient documentation generator is found to reduce redundancy.