### PR TITLE
added spec for chains file and modified lock file

### DIFF
--- a/chains-file-spec.md
+++ b/chains-file-spec.md
@@ -1,0 +1,97 @@
+# Chain File Specification
+
+This document defines the specification for the **Chain File**.  The
+chain file is a dynamically updated file holding information about where contracts are
+deployed at on different chains. This is an optional file to download, it is meant purely 
+to save the cost of redeployment. In the case that it is present, it should be a hidden file. 
+
+** Problem: How do we dynamically update this file from multiple parties? How do we ensure its integrity? How do we prevent spam? **
+
+## Guiding Principles
+
+The chain file specification makes the following assumptions about the
+document lifecycle.
+
+1. Chain files are intended to be generated programatically by package management software as part of the deployment process.
+2. Chain files will be consumed by package managers during tasks like linking and deploying packages containing libraries or contracts of particular interest.
+3. Chain files are dynamic whereas the manifest and lock files are static. This is to be updated every time there is a new deploy of the package onto a release chain to be actually utilized by multiple parties.
+
+
+## Filename
+
+When deploying, if it exists, the referenced file should be a hidden `.packageName-chains.json` file where `packageName` denotes the name of the package. Hidden because we don't want to spam this thing to hell.
+
+## Format
+
+The canonical format for the chain file is a JSON document containing a
+single JSON object.
+
+### Chain File Version: `chain_file_version`
+
+The `chain_file_version` field defines the specification version that this
+document conforms to.  All chain files **must** include this field.
+
+* Key: `chain_file_version`
+* Type: Integer
+* Allowed Values: `1`
+
+### Release File Hash: `release_hash`
+
+The `release_hash` field defines a keccak256 hash of the release lock file that this document conforms to.
+All chain files **must** include this field.
+
+* Key: `release_hash`
+* Type: String
+
+
+The following fields reference a blockchain as defined using
+a subset of the [BIP-122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) spec, specified below:
+
+```
+<chainID>://<genesis_hash>/block/<latest block hash>
+```
+
+We will break this into portions
+### ChainID: `chainID`
+
+The `chainID` field defines the blockchain that should be used for any addresses
+provided with this package. This field **must** be present.
+* Key: `chainID`
+* Type: String mapping to list of genesis hashes
+
+### Genesis Hash: `genesis_hash`
+
+The `genesis_hash` represents the blockhash of the first block on the chain. This field **must** be present.
+* Key: `genesis_hash`
+* Type: string mapping to list of `contract` strings
+
+### Contract Object: `contract`
+
+A contract object containing information on addresses and deploy times. Similar to contract instance object in lock file.
+* Key: `contract`
+* Type: String mapping to list of deploy objects
+
+### Deploy Objects: `deployed`
+An object containing an `address`, and either a `deploy_block` or `deploy_transaction`.
+* Key: `deployed`
+* Type: Object
+
+* `address`:
+    * Required
+    * Type: String
+    * Format: Hex encoded ethereum address of the deployed contract.
+* `deploy_transaction`:
+    * Required if `deploy_block` not specified
+    * Type: String
+    * Format: [BIP122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) URI which defines the transaction in which this contract was created.
+* `deploy_block`:
+    * Required if `deploy_transaction` not specified
+    * Type: String
+    * Format: [BIP122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) URI which defines the block in which this contract was created.
+
+### Latest Block Hash: `latest_block_hash`
+
+`<latest block hash>` represents the hash of the latest block that's been reliably confirmed. This is not required but is strongly recommended.
+
+*If* this release lock file includes any addressed contracts
+this field **must** be present. 

--- a/release-lock-file-spec.md
+++ b/release-lock-file-spec.md
@@ -11,9 +11,9 @@ The release lock file specification makes the following assumptions about the
 document lifecycle.
 
 1. Release lock files are intended to be generated programatically by package management software as part of the release process.
-2. Release lock files will be consumed by package managers during tasks like installing package dependencies or building and deploying new releases.
+2. Release lock files will be consumed by package managers during tasks like installing package dependencies.
 3. Release lock files will typically **not** be stored alongside the source, but rather by package registries *or* referenced by package registries and stored in something akin to IPFS.
-
+4. Release lock files are static. Once the release is in, they **should not** be updated further.
 
 ## Format
 
@@ -90,26 +90,6 @@ Sources are declared in a key/value mapping.
 * Type: Object (String: String)
 
 
-### Chain: `chain`
-
-The `chain` field defines the blockchain that should be used for any addresses
-provided with this package.  A blockchain is defined using
-a subset of the [BIP-122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) spec, specified below:
-
-```
-blockchain://<genesis_hash>/block/<latest block hash>
-```
-
-The `<genesis hash>` represents the blockhash of the first block on the chain, and `<latest block hash>` represents the hash of the latest block that's been reliably confirmed (package managers should be free to choose their desired level of confirmations).
-
-*If* this release lock file includes any addressed contracts
-this field **must** be present. 
-
-* Key: `chain`
-* Type: String
-* Format: `blockchain://[0-9a-fA-F]{64}/block/[0-9a-fA-F]{64}`
-
-
 ### Contracts: `contracts`
 
 The `contracts` field declares information about the deployed contracts
@@ -147,18 +127,6 @@ A *Contract Instance Object* is an object with the following key/values.
     * Required: Yes
     * Type: String
     * Format: Valid contract name matching regular expression `[_a-zA-Z][_a-zA-Z0-9]*]`
-* `address`:
-    * Required: No
-    * Type: String
-    * Format: Hex encoded ethereum address of the deployed contract.
-* `deploy_transaction`:
-    * Required: No
-    * Type: String
-    * Format: [BIP122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) URI which defines the transaction in which this contract was created.
-* `deploy_block`:
-    * Required: No
-    * Type: String
-    * Format: [BIP122](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki) URI which defines the block in which this contract was created.
 * `bytecode`:
     * Required: No
     * Type: String


### PR DESCRIPTION
Problem: Currently we have chain related information inside the lock file. This is problematic because the lock file is meant to be a release file, and it shouldn't be updated once it's released. But say that I deploy my contract on a new chain after the release and want to keep that information somewhere that it was in fact deployed. This requires us to update the lock file...which is bad practice for a release.

Solution: Separate dependencies from linking. Linking can be done either by deploying a copy of contract libraries at new addresses or by simply referencing this chains file. The only problem I'm forseeing is how do we enable it to be dynamically updated and still easily trackable while also keeping it decentralized. Indeed a very difficult problem methinks. Anyways. Let me know what you think. I feel pushback a coming. 

Signed-off-by: VoR0220 <rj@erisindustries.com>