### PR TITLE
Further refine the package name definitions

### DIFF
--- a/package-manifest-spec.md
+++ b/package-manifest-spec.md
@@ -53,10 +53,14 @@ specification (this document) that this manifest conforms to. All manifests
 ### Package Name: `package_name`
 
 The `package_name` field defines a human readable name for this package.  All
-manifests **must** include this field.
+manifests **must** include this field.  All package names **must** begin with a
+lowercase letter and be comprised of only lowercase letters, numeric
+characters, and the dash character `'-'`.  Package names **must** not exceed
+214 characters in length.
 
 * Key: `package_name`
 * Type: String
+* Format: All package names must conform to the following regular expression. `[a-z][-a-z0-9]{0,213}`
 
 ### Authors: `authors`
 
@@ -138,7 +142,7 @@ the *Release Lock File*.
 the `dependencies` field defines a key/value mapping of ethereum packages that
 this project depends on.
 
-* All keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9_]{0,214}`
+* All keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9]{0,213}`
 * All values **must** conform to *one of* the following formats:
     * IPFS URI:
         * The resolved document **must** be a valid *release lock file*.

--- a/release-lock-file-spec.md
+++ b/release-lock-file-spec.md
@@ -125,7 +125,7 @@ included within this release.
 the `dependencies` field defines a key/value mapping of ethereum packages that
 this project depends on.
 
-* All keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9_]{0,214}`
+* All keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9]{0,213}`
 * All values **must** conform to *one of* the following formats:
     * IPFS URI:
         * The resolved document **must** be a valid *release lock file*.

--- a/spec/package-manifest.schema.json
+++ b/spec/package-manifest.schema.json
@@ -9,7 +9,7 @@
       "title": "Package Name",
       "type": "string",
       "description": "TODO",
-      "pattern": "^[a-z][-a-z0-9_]{0,214}$"
+      "pattern": "^[a-z][-a-z0-9]{0,213}$"
     },
     "manifest_version": {
       "type": "integer",
@@ -81,7 +81,7 @@
       "description": "TODO",
       "type": "object",
       "patternProperties": {
-        "^[a-z][-a-z0-9_]{0,214}$": {
+        "^[a-z][-a-z0-9]{0,213}$": {
           "title": "Dependency",
           "type": "string",
           "description": "TODO"

--- a/spec/release-lock-file.schema.json
+++ b/spec/release-lock-file.schema.json
@@ -51,7 +51,7 @@
       "type": "object",
       "description": "TODO",
       "patternProperties": {
-        "^[a-z][-a-z0-9_]{0,214}$": {
+        "^[a-z][-a-z0-9]{0,213}$": {
           "title": "Dependency",
           "type": "string",
           "description": "TODO"


### PR DESCRIPTION
This further refines the package name definistion.

* Provide a human readable description of the definition.
* Remove the allowance of `_` from package names.
* Fix the overall length to actually be 214 characters (again, magic number from npm.  I'm open to alternatives.)