### PR TITLE
update spec to only allow IPFS URI's in the build dependencies

### DIFF
--- a/release-lock-file-spec.md
+++ b/release-lock-file-spec.md
@@ -108,15 +108,12 @@ included within this release.
 the `dependencies` field defines a key/value mapping of ethereum packages that
 this project depends on.
 
-* All keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9]{0,213}`
-* All values **must** conform to *one of* the following formats:
-    * IPFS URI:
-        * The resolved document **must** be a valid *release lock file*.
-    * Version String that resolves to a specific package version.
-
 
 * Key: `dependencies`
 * Type: Object (String: String)
+* Format:
+    * All keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9]{0,213}`
+    * All values **must** be valid IPFS URIs which resolve to a valid *Release Lock File*
 
 
 #### The *Contract* Object

--- a/spec/release-lock-file.schema.json
+++ b/spec/release-lock-file.schema.json
@@ -41,9 +41,11 @@
       "description": "TODO",
       "patternProperties": {
         "^[a-z][-a-z0-9]{0,213}$": {
-          "title": "Dependency",
+          "title": "IPFS URI to dependency Release Lock File",
           "type": "string",
-          "description": "TODO"
+          "description": "TODO",
+          "format": "uri",
+          "pattern": "^ipfs:/?/?*$"
         }
       }
     },


### PR DESCRIPTION
### What was wrong

In the Release Lock File the `build_dependencies` allow declaring the dependency as

```javascript
{
  'build_dependencies': {
    "owned": "1.0.0",
  }
}
```

This is problematic because it means that installation is no longer deterministic because it depends on the registry.

### How was it fixed

Remove the allowance of specifying version number so that all `build_dependencies` must be IPFS URIs

#### Cute Animal Picture

![grizz5](https://cloud.githubusercontent.com/assets/824194/21206561/2d224bfe-c220-11e6-9ef5-48659d0500cf.jpeg)
