### PR TITLE
Add license field to Source Object

### DIFF
--- a/docs/source/v3-package-spec.rst
+++ b/docs/source/v3-package-spec.rst
@@ -472,7 +472,7 @@ package. This value **should** conform to the
 `SPDX <https://en.wikipedia.org/wiki/Software_Package_Data_Exchange>`__
 format. Packages **should** include this field. If a file `Source Object`_
 defines its own license, that license takes precedence for that particular
-file over the package-scoped ``meta`` license.
+file over this package-scoped ``meta`` license.
 
   :Required: No
   :Key: ``license``
@@ -586,8 +586,7 @@ License: ``license``
 
 The ``license`` field declares the type of license associated with
 this source file. When defined, this license overrides the
-package-scoped `Meta License`_. If undefined, this file extends the
-package-scoped license.
+package-scoped `Meta License`_.
 
   :Required: No
   :Key: ``license``

--- a/docs/source/v3-package-spec.rst
+++ b/docs/source/v3-package-spec.rst
@@ -462,6 +462,8 @@ authors of this package. Packages **may** include this field.
   :Key: ``authors``
   :Type: Array (String)
 
+.. _Meta License:
+
 License: ``license``
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -577,6 +579,18 @@ of the following values: ``jsonabi``, ``solidity``, ``vyper``.
 
   :Required: No
   :Key: ``type``
+  :Type: String
+
+License: ``license``
+^^^^^^^^^^^^^^^^^^^^
+
+The ``license`` field declares the type of license associated with
+this source file. When defined, this license overrides the
+package-scoped `Meta License`_. If undefined, this file extends the
+package-scoped license.
+
+  :Required: No
+  :Key: ``license``
   :Type: String
 
 ----

--- a/docs/source/v3-package-spec.rst
+++ b/docs/source/v3-package-spec.rst
@@ -575,7 +575,7 @@ Type: ``type``
 ^^^^^^^^^^^^^^
 
 The ``type`` field declares the type of the source file. The field **should** be one
-of the following values: ``jsonabi``, ``solidity``, ``vyper``. 
+of the following values: ``solidity``, ``vyper``, ``abi-json``, ``solidity-ast-json``. 
 
   :Required: No
   :Key: ``type``

--- a/spec/v3.spec.json
+++ b/spec/v3.spec.json
@@ -116,6 +116,11 @@
 		  "title": "Type",
 		  "description": "File type of this source",
 		  "type": "string"
+		},
+		"license": {
+		  "title": "License",
+		  "description": "The license associated with the source file",
+		  "type": "string"
 		}
 	  }
 	},


### PR DESCRIPTION
It was decided in the gitter channel that the ethpm spec should also explicitly define a `"license"` field for individual source objects - in addition the the `"license"` defined in the top-level `"meta"` object.